### PR TITLE
Provider Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade minimum supported provider version to `v4.6` since it includes a fix
+  for a critical bugs that didn't allow to update labels after the initial creation.
+  For details please see https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md#460-january-10-2021
+
 ## [0.0.2]
 
 ### Added

--- a/test/unit-minimal/main.tf
+++ b/test/unit-minimal/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.1"
+      version = "4.6"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.1"
+      version = "~> 4.6"
     }
   }
 }


### PR DESCRIPTION
Upgrade minimum supported version of the google provider to `v4.6` to fix a critical bug in the label definition of the resource. For details please see https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md#460-january-10-2021