### PR TITLE
Only run unit-tests if relevant files have been changed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Run pre-commit
         run: make test/pre-commit
+
   unit-tests:
     needs: pre-commit
     runs-on: ubuntu-latest
@@ -32,5 +33,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Check for Terraform file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: |
+            terraform:
+              - '**/*.tf'
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+
       - name: Run Unit Tests
+        if: steps.changes.outputs.terraform == 'true'
         run: make test/unit-tests


### PR DESCRIPTION
At the moment in GitHub Actions, path filters are only available on a per action level but not per jobs:

- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
- https://github.community/t/path-filtering-for-jobs-and-steps/16447

This PR contains an improvement that is using the getsentry/paths-filter@v2 GitHub actions to only run the unit-tests if `*.tf` or `*.go` files have been changed, otherwise they will be skipped to reduce the build-time consumption in GH Actions and to unblock PRs faster.

For a test run please see #7 